### PR TITLE
Fix syntax errors in template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ PLUGIN_NAME = f"pymodaq_plugins_{SHORT_PLUGIN_NAME}"
 
 from pathlib import Path
 
+if not SHORT_PLUGIN_NAME.isidentifier():
+    raise ValueError("'SHORT_PLUGIN_NAME = %s' is not a valid python identifier." % SHORT_PLUGIN_NAME)
+
 with open(str(Path(__file__).parent.joinpath(f'src/{PLUGIN_NAME}/VERSION')), 'r') as fvers:
     version = fvers.read().strip()
 

--- a/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
+++ b/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
@@ -79,7 +79,7 @@ class DAQ_Move_Template(DAQ_Move_base):
         ## TODO for your custom plugin
         if param.name() == "a_parameter_you've_added_in_self.params":
            self.controller.your_method_to_apply_this_param_change()
-        elif ...
+#        elif ...
         ##
 
     def ini_stage(self, controller=None):

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
@@ -22,7 +22,7 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
         ## TODO for your custom plugin
         if param.name() == "a_parameter_you've_added_in_self.params":
            self.controller.your_method_to_apply_this_param_change()
-        elif ...
+#        elif ...
         ##
 
     def ini_detector(self, controller=None):

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
@@ -24,7 +24,7 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
         ## TODO for your custom plugin
         if param.name() == "a_parameter_you've_added_in_self.params":
            self.controller.your_method_to_apply_this_param_change()
-        elif ...
+#        elif ...
         ##
 
     def ini_detector(self, controller=None):
@@ -65,8 +65,8 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
             #initialize viewers pannel with the future type of data
             self.data_grabed_signal_temp.emit([DataFromPlugins(name='Mock1',data=[np.array([0.,0.,...]),
                                                                              np.array([0.,0.,...])],
-                                                          dim='Data1D', labels=['Mock1', 'label2']),
-                                                          x_axis = self.x_axis],)
+                                                          dim='Data1D', labels=['Mock1', 'label2'],
+                                                          x_axis=self.x_axis),])
 
             ##############################
 

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
@@ -25,7 +25,7 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
         ## TODO for your custom plugin
         if param.name() == "a_parameter_you've_added_in_self.params":
             self.controller.your_method_to_apply_this_param_change()
-        elif ...
+#        elif ...
 
     ##
 
@@ -70,8 +70,9 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
             ## TODO for your custom plugin
             # initialize viewers pannel with the future type of data
             self.data_grabed_signal_temp.emit([DataFromPlugins(name='Mock1', data=["2D numpy array"],
-                                                  dim='Data2D', labels=['dat0']),
-                                                  x_axis=self.x_axis, y_axis=self.y_axis], )
+                                                  dim='Data2D', labels=['dat0'],
+                                                  x_axis=self.x_axis,
+                                                  y_axis=self.y_axis), ])
 
             ##############################
 


### PR DESCRIPTION
Hi,

I'm trying to implement a plugin for pymodaq (for attocube hardware).

Trying to install the base template, I ran into some syntax errors on calls to self.data_grabed_signal_temp

They should be fixed by this pull request.